### PR TITLE
Reorganize specs

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --require spec_helper
+--order rand

--- a/lib/todo/client.rb
+++ b/lib/todo/client.rb
@@ -1,6 +1,8 @@
 module Todo
   class << self
     def client
+      verify_todo_dir
+
       return client_from_username unless File.exists?(USER_CONFIG_PATH)
 
       user_profile = YAML.load_file(USER_CONFIG_PATH)

--- a/lib/todo/run.rb
+++ b/lib/todo/run.rb
@@ -1,8 +1,6 @@
 module Todo
   class << self
     def run(args: {})
-      verify_todo_dir
-
       case args[0]
       when "create"
         create_list(name: args[1])

--- a/lib/todo/run.rb
+++ b/lib/todo/run.rb
@@ -4,20 +4,20 @@ module Todo
       verify_todo_dir
 
       case args[0]
-      when "list"
-        show_list(id: args[1])
-      when "update"
-        update_list(id: args[1], name: args[2])
-      when "delete"
-        delete(args)
-      when "lists"
-        all_lists
       when "create"
         create_list(name: args[1])
-      when "item"
-        create_item(list_id: args[1], name: args[2])
+      when "delete"
+        delete(args)
       when "finish"
         finish_item(list_id: args[1], id: args[2])
+      when "item"
+        create_item(list_id: args[1], name: args[2])
+      when "list"
+        show_list(id: args[1])
+      when "lists"
+        all_lists
+      when "update"
+        update_list(id: args[1], name: args[2])
       else
         $stdout.puts help
       end

--- a/spec/todo_spec.rb
+++ b/spec/todo_spec.rb
@@ -24,16 +24,16 @@ RSpec.describe Todo do
     @todo_dir ||= File.expand_path(".todo", "spec")
   end
 
+  before(:all) do
+    FileUtils.rm_rf(todo_dir)
+  end
+
   before(:each) do
     allow($stdout).to receive(:puts)
     stub_const("Todo::TODO_DIR", todo_dir)
     stub_const("Todo::USER_CONFIG_PATH", File.join(todo_dir, "user"))
     stub_const("Todo::LISTS_PATH", File.join(todo_dir, "lists"))
     allow(Todoable::Client).to receive(:new).with(token: "abcdef", expires_at: anything).and_return(mock_client)
-  end
-
-  before(:all) do
-    FileUtils.rm_rf(todo_dir)
   end
 
   after(:all) do

--- a/spec/todo_spec.rb
+++ b/spec/todo_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Todo do
   end
 
   before(:each) do
+    allow($stdout).to receive(:puts)
     stub_const("Todo::TODO_DIR", todo_dir)
     stub_const("Todo::USER_CONFIG_PATH", File.join(todo_dir, "user"))
     stub_const("Todo::LISTS_PATH", File.join(todo_dir, "lists"))


### PR DESCRIPTION
    Reorganize specs and run in random order.
    
    The first version of these specs relied on being run in a specific
    order, because it set up authentication credentials in the first specs
    which were used by the later ones.
    
    I've reorganized it so the specs run in random order, and don't rely on
    authentication from earlier specs.